### PR TITLE
Use correct pluralized words to fix Jekyll Hooks.

### DIFF
--- a/lib/octopress-date-format.rb
+++ b/lib/octopress-date-format.rb
@@ -117,7 +117,11 @@ module Octopress
         DateFormat.config = site.config
       end
 
-      Jekyll::Hooks.register [:page, :post], :post_init do |item|
+      Jekyll::Hooks.register :posts, :pre_render do |item|
+        DateFormat.hack_date(item)
+      end
+
+      Jekyll::Hooks.register :pages, :post_init do |item|
         DateFormat.hack_date(item)
       end
     else

--- a/lib/octopress-date-format/version.rb
+++ b/lib/octopress-date-format/version.rb
@@ -1,5 +1,5 @@
 module Octopress
   module DateFormat
-    VERSION = "3.0.3"
+    VERSION = "3.0.4"
   end
 end

--- a/test/_expected/2014/07/03/welcome-to-jekyll.html
+++ b/test/_expected/2014/07/03/welcome-to-jekyll.html
@@ -1,6 +1,4 @@
 
-  
-
 ## Date
 - Date: 2014-07-03 14:08:00 +0000
 - Formatted Date: Jul 3rd, 2014

--- a/test/_expected/index.html
+++ b/test/_expected/index.html
@@ -1,6 +1,24 @@
 
 
-  
+## Date
+- Date: 2014-07-03 14:08:00 +0000
+- Formatted Date: Jul 3rd, 2014
+- Formatted Time: 2:08 pm
+- Date XML: 2014-07-03T14:08:00+00:00
+- Date HTML: <time class='entry-date' datetime='2014-07-03T14:08:00+00:00'><span class='date'><span class='date-month'>Jul</span> <span class='date-day'>3</span><span class='date-suffix'>rd</span>, <span class='date-year'>2014</span></span></time>
+- Date Time HTML: <time class='entry-date' datetime='2014-07-03T14:08:00+00:00'><span class='date'><span class='date-month'>Jul</span> <span class='date-day'>3</span><span class='date-suffix'>rd</span>, <span class='date-year'>2014</span></span> <span class='time'>2:08 pm</span></time>
+
+
+## Updated
+- Date: 2014-07-04 16:03:05 +0000
+- Formatted Date: Jul 4th, 2014
+- Formatted Time: 4:03 pm
+- XML: 2014-07-04T16:03:05+00:00
+- HTML: <time class='updated' datetime='2014-07-04T16:03:05+00:00'><span class='date'><span class='date-month'>Jul</span> <span class='date-day'>4</span><span class='date-suffix'>th</span>, <span class='date-year'>2014</span></span></time>
+- Date Time HTML: <time class='updated' datetime='2014-07-04T16:03:05+00:00'><span class='date'><span class='date-month'>Jul</span> <span class='date-day'>4</span><span class='date-suffix'>th</span>, <span class='date-year'>2014</span></span> <span class='time'>4:03 pm</span></time>
+
+
+
 
 ## Date
 - Date: 2014-07-03 14:08:00 +0000
@@ -18,28 +36,6 @@
 - XML: 2014-07-03T15:03:15+00:00
 - HTML: <time class='updated' datetime='2014-07-03T15:03:15+00:00'><span class='date'><span class='date-month'>Jul</span> <span class='date-day'>3</span><span class='date-suffix'>rd</span>, <span class='date-year'>2014</span></span></time>
 - Date Time HTML: <time class='updated' datetime='2014-07-03T15:03:15+00:00'><span class='date'><span class='date-month'>Jul</span> <span class='date-day'>3</span><span class='date-suffix'>rd</span>, <span class='date-year'>2014</span></span> <span class='time'>3:03 pm</span></time>
-
-
-
-
-  
-
-## Date
-- Date: 2014-07-03 14:08:00 +0000
-- Formatted Date: Jul 3rd, 2014
-- Formatted Time: 2:08 pm
-- Date XML: 2014-07-03T14:08:00+00:00
-- Date HTML: <time class='entry-date' datetime='2014-07-03T14:08:00+00:00'><span class='date'><span class='date-month'>Jul</span> <span class='date-day'>3</span><span class='date-suffix'>rd</span>, <span class='date-year'>2014</span></span></time>
-- Date Time HTML: <time class='entry-date' datetime='2014-07-03T14:08:00+00:00'><span class='date'><span class='date-month'>Jul</span> <span class='date-day'>3</span><span class='date-suffix'>rd</span>, <span class='date-year'>2014</span></span> <span class='time'>2:08 pm</span></time>
-
-
-## Updated
-- Date: 2014-07-04 16:03:05 +0000
-- Formatted Date: Jul 4th, 2014
-- Formatted Time: 4:03 pm
-- XML: 2014-07-04T16:03:05+00:00
-- HTML: <time class='updated' datetime='2014-07-04T16:03:05+00:00'><span class='date'><span class='date-month'>Jul</span> <span class='date-day'>4</span><span class='date-suffix'>th</span>, <span class='date-year'>2014</span></span></time>
-- Date Time HTML: <time class='updated' datetime='2014-07-04T16:03:05+00:00'><span class='date'><span class='date-month'>Jul</span> <span class='date-day'>4</span><span class='date-suffix'>th</span>, <span class='date-year'>2014</span></span> <span class='time'>4:03 pm</span></time>
 
 
 

--- a/test/_expected/page.html
+++ b/test/_expected/page.html
@@ -1,6 +1,4 @@
 
-  
-
 ## Date
 - Date: 2013-08-16 14:08:15 +0000
 - Formatted Date: Aug 16th, 2013


### PR DESCRIPTION
Use correct pluralized words in Jekyll Hooks. Move 'pages' hook to pre_render so that it has time to load the front matter.

---

Attempting to move my blog over to Octopress 3.0 and found this plugin to be broken with Jekyll 3.1.6 because the Jekyll Hooks integration was not specified correctly. Singular vs plural in the symbols. https://jekyllrb.com/docs/plugins/#hooks

Clash test was broken when I forked it. Fixed the clash expectation in the process. Seems to be passing now.

Hope you can pull this in soon so I can use this plugin. :)
