### PR TITLE
Update octopress-date-format.rb

### DIFF
--- a/lib/octopress-date-format.rb
+++ b/lib/octopress-date-format.rb
@@ -117,7 +117,7 @@ module Octopress
         DateFormat.config = site.config
       end
 
-      Jekyll::Hooks.register [:pages, :posts, :documents], :post_init do |item|
+      Jekyll::Hooks.register [:pages, :posts, :documents], :pre_render do |item|
         DateFormat.hack_date(item)
       end
     else

--- a/lib/octopress-date-format.rb
+++ b/lib/octopress-date-format.rb
@@ -117,7 +117,7 @@ module Octopress
         DateFormat.config = site.config
       end
 
-      Jekyll::Hooks.register [:page, :post], :post_init do |item|
+      Jekyll::Hooks.register [:pages, :posts], :post_init do |item|
         DateFormat.hack_date(item)
       end
     else

--- a/lib/octopress-date-format.rb
+++ b/lib/octopress-date-format.rb
@@ -117,7 +117,7 @@ module Octopress
         DateFormat.config = site.config
       end
 
-      Jekyll::Hooks.register [:pages, :posts], :post_init do |item|
+      Jekyll::Hooks.register [:pages, :posts, :documents], :post_init do |item|
         DateFormat.hack_date(item)
       end
     else


### PR DESCRIPTION
fixed names of hooks. They are called :pages and :posts
