### PR TITLE
Updated hook registers to also work with modern Jekyll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ tmp
 .DS_Store
 _site
 .jekyll-metadata
+.idea
+.ruby-version
+.ruby-gemset
+.jekyll-cache

--- a/lib/octopress-date-format.rb
+++ b/lib/octopress-date-format.rb
@@ -117,7 +117,7 @@ module Octopress
         DateFormat.config = site.config
       end
 
-      Jekyll::Hooks.register [:page, :post, :pages, :posts], :post_init do |item|
+      Jekyll::Hooks.register [:page, :post, :pages, :posts], :pre_render do |item|
         DateFormat.hack_date(item)
       end
     else

--- a/lib/octopress-date-format.rb
+++ b/lib/octopress-date-format.rb
@@ -68,7 +68,7 @@ module Octopress
         date.strftime(format)
       end
 
-      # Returns an ordidinal date eg July 22 2007 -> July 22nd 2007
+      # Returns an ordinal date eg July 22 2007 -> July 22nd 2007
       def ordinalize(date)
         "#{date.strftime('%b %-d')}#{ordinal_suffix(date)}, #{date.strftime('%Y')}"
       end
@@ -117,7 +117,7 @@ module Octopress
         DateFormat.config = site.config
       end
 
-      Jekyll::Hooks.register [:page, :post], :post_init do |item|
+      Jekyll::Hooks.register [:page, :post, :pages, :posts], :post_init do |item|
         DateFormat.hack_date(item)
       end
     else

--- a/lib/octopress-date-format/version.rb
+++ b/lib/octopress-date-format/version.rb
@@ -1,5 +1,5 @@
 module Octopress
   module DateFormat
-    VERSION = "3.0.3"
+    VERSION = "3.0.4"
   end
 end

--- a/test/_config.yml
+++ b/test/_config.yml
@@ -1,6 +1,8 @@
 name: Your New Jekyll Site
 markdown: kramdown
 timezone: UTC
+plugins:
+  - octopress-date-format
 gems:
   - octopress-date-format
 exclude:


### PR DESCRIPTION
Jekyll's hook container names changed almost 5 years ago! https://github.com/jekyll/jekyll/commit/b89f943bf22bd7f36c8378791ca543e16a59f442

Keeping the old names for backwards compatibility.

I've also changed the hook to `pre_render` since `post_init` was resulting in current date/time rather than post's date time. Suspecting the `post_init` hook executes before the front matter is actually processed.